### PR TITLE
Minor change defaulting user language in copyright description

### DIFF
--- a/scripts/main/wallpaper.js
+++ b/scripts/main/wallpaper.js
@@ -67,7 +67,8 @@ function updateWallpaper(idx){
 			// showDefaultWallpaper();
 		}
 	}
-	xhr.open('get','https://www.bing.com/HPImageArchive.aspx?format=js&n=1&mkt=zh-CN&idx=' + idx);
+	let userLang = window.navigator.language;
+	xhr.open('get',`https://www.bing.com/HPImageArchive.aspx?format=js&n=1&mkt=${userLang}&idx=${idx}`);
 	xhr.send(null);
 }
 


### PR DESCRIPTION
the xhr request by default sends language code in zh-CN, changing it to user language